### PR TITLE
Fix #9: Type of `openingStock` attribute

### DIFF
--- a/models/product.js
+++ b/models/product.js
@@ -15,7 +15,7 @@ const productSchema = new mongoose.Schema(
 
 		// Stock information
 		openingStock: {
-			type: String,
+			type: Number,
 			required: true,
 		},
 		stockType: { type: String, required: true },


### PR DESCRIPTION
## Summary
This PR fixes the issue described in the #9 .

## Technical Details 
To implement the type of `openingStock` attribute was changed from **String** -> **Number**.

## Testing
No testing has been introduced till now in the project.

## Screenshots
![image](https://github.com/Shivansh-Khunger/service-management/assets/110467229/234c699e-909a-448d-bd85-ae35a082cd88)


## Request for Feedback
I'd appreciate feedback on the new error handling methods and any suggestions for improvement.