### PR TITLE
🍭 Feature: Add **cron-job** for deletion

### DIFF
--- a/.github/workflows/delExpDealsCron.yml
+++ b/.github/workflows/delExpDealsCron.yml
@@ -15,7 +15,7 @@ jobs:
               with:
                   sparse-checkout: |
                       .github
-                      src/jobs/DeleteExpiredDealsJob.ts
+                      src/jobs/delExpDealsJob.ts
                       src/models/Deals.ts
 
             - uses: actions/setup-node@v4
@@ -32,7 +32,7 @@ jobs:
               run: npm ci --ignore-scripts
 
             - name: Compile Typescript
-              run: npx tsc ./src/jobs/DeleteExpiredDealsJob.ts
+              run: npx tsc ./src/jobs/delExpDealsJob.ts
 
             - name: Run Compiled Job
-              run: npx dotenvx run -- node ./src/jobs/DeleteExpiredDealsJob.js
+              run: npx dotenvx run -- node ./src/jobs/delExpDealsJob.js

--- a/src/jobs/delExpDealsJob.ts
+++ b/src/jobs/delExpDealsJob.ts
@@ -1,32 +1,47 @@
+// Importing required modules
 import mongoose from "mongoose";
 import Deals from "../models/deal";
 
+// Function to delete expired deals
 async function dealetedExpiredDeals() {
+    // Connect to MongoDB using the URI in the environment variables
     await mongoose
         .connect(process.env.MONGO_URI as string)
         .then(() => {
+            // Log a message when the database connection is successful
             console.log("db connected !");
 
+            // Delete all deals where the end date is less than or equal to the current date/time
             Deals.deleteMany({
                 endDate: { $lte: Date.now() },
             });
 
+            // Close the database connection
             mongoose.connection.close();
         })
         .catch((err) => {
+            // Log an error message if the database connection fails
             console.log(
                 err,
                 "-> an error has occured while connecting to the db!",
             );
 
+            // Exit the process with a failure status code
             process.exit(1);
         });
 }
 
+// Immediately invoked function expression (IIFE) to run the deleteExpiredDeals function
 (async () => {
+    // Run the function to delete expired deals
     await dealetedExpiredDeals();
 
+    // Log a message indicating that the query has been sent to the database
     console.log("query to delete expired Deals has been sent to db!");
+
+    // Log a message indicating that the process is exiting
     console.log("exiting ...");
+
+    // Exit the process with a success status code
     process.exit(0);
 })();


### PR DESCRIPTION
## Summary

This PR implements a **cron-job** which will delete expired deals in the db.

## Technical Details

To implement this the following steps were taken -:

1. `.github/workflows/delExpDealsCron.yml` was implemented. (It will run every 4 hours due to the current traffic being nearly zero)
2. `src/jobs/delExpDealsJob.ts` was implemented which is the logic behind the **cron-job**.
3. This PR does not cover everything as test and trial for this workflow was done on a different branch and this is a new branch created just for sane purposes. In the branch through trial and error this workflow and file is perfected.
Perfection for both the files was done simultaneously -:

- Caching was added for better performance.
- Only the files needed along with the root files were used only.
- The `src/jobs/delExpDealsJob.ts` gracefully exists and sends the request to delete and does not await for better performance.

## Testing

The most difficult of testing this was that this a **cron-job** and even when timing set to 5 minutes it did not run in every 5 minutes. The thought to test locally came into my mind but it is simply not **possible** and the worst part was that I could not initiate a workflow manually when it is a **cron-job**. Even when I re-ran the job on **github** workflow it uses the old workflow file not the updated one I mean why?

## Screenshots

N/A

## Request for Feedback

I'd appreciate feedback on the implementation of this **cron-job** and any suggestions for improvement.
